### PR TITLE
feat(metrics): add of temporal and environmental score handling

### DIFF
--- a/src/humanizer.ts
+++ b/src/humanizer.ts
@@ -1,7 +1,7 @@
-import { BaseMetric, BaseMetricValue } from './models';
+import { BaseMetric, Metric, MetricValue } from './models';
 
-export const humanizeBaseMetric = (baseMetric: BaseMetric): string => {
-  switch (baseMetric) {
+export const humanizeBaseMetric = (metric: Metric): string => {
+  switch (metric) {
     case BaseMetric.ATTACK_VECTOR:
       return 'Attack Vector';
     case BaseMetric.ATTACK_COMPLEXITY:
@@ -25,8 +25,8 @@ export const humanizeBaseMetric = (baseMetric: BaseMetric): string => {
 
 // eslint-disable-next-line complexity
 export const humanizeBaseMetricValue = (
-  value: BaseMetricValue,
-  metric: BaseMetric
+  value: MetricValue,
+  metric: Metric
 ): string => {
   switch (value) {
     case 'A':

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,6 +9,26 @@ export enum BaseMetric {
   AVAILABILITY = 'A'
 }
 
+export enum TemporalMetric {
+  EXPLOITABILITY = 'E',
+  REMEDIATION_LEVEL = 'RL',
+  REPORT_CONFIDENCE = 'RC'
+}
+
+export enum EnvironmentalMetric {
+  ATTACK_VECTOR = 'MAV',
+  ATTACK_COMPLEXITY = 'MAC',
+  PRIVILEGES_REQUIRED = 'MPR',
+  USER_INTERACTION = 'MUI',
+  SCOPE = 'MS',
+  CONFIDENTIALITY = 'MC',
+  INTEGRITY = 'MI',
+  AVAILABILITY = 'MA',
+  CONFIDENTIALITY_REQUIREMENT = 'CR',
+  INTEGRITY_REQUIREMENT = 'IR',
+  AVAILABILITY_REQUIREMENT = 'AR'
+}
+
 export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.ATTACK_VECTOR,
   BaseMetric.ATTACK_COMPLEXITY,
@@ -20,9 +40,27 @@ export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.AVAILABILITY
 ];
 
-export type BaseMetricValue = 'A' | 'C' | 'H' | 'L' | 'N' | 'P' | 'R' | 'U';
+export const temporalMetrics: Metrics<TemporalMetric> = [
+  TemporalMetric.EXPLOITABILITY,
+  TemporalMetric.REMEDIATION_LEVEL,
+  TemporalMetric.REPORT_CONFIDENCE
+];
 
-export const baseMetricValues: Record<BaseMetric, BaseMetricValue[]> = {
+export const environmentalMetrics: Metrics<EnvironmentalMetric> = [
+  EnvironmentalMetric.ATTACK_VECTOR,
+  EnvironmentalMetric.ATTACK_COMPLEXITY,
+  EnvironmentalMetric.PRIVILEGES_REQUIRED,
+  EnvironmentalMetric.USER_INTERACTION,
+  EnvironmentalMetric.SCOPE,
+  EnvironmentalMetric.CONFIDENTIALITY,
+  EnvironmentalMetric.INTEGRITY,
+  EnvironmentalMetric.AVAILABILITY,
+  EnvironmentalMetric.AVAILABILITY_REQUIREMENT,
+  EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT,
+  EnvironmentalMetric.INTEGRITY_REQUIREMENT
+];
+
+export const baseMetricValues: MetricValues<BaseMetric, BaseMetricValue[]> = {
   [BaseMetric.ATTACK_VECTOR]: ['N', 'A', 'L', 'P'],
   [BaseMetric.ATTACK_COMPLEXITY]: ['L', 'H'],
   [BaseMetric.PRIVILEGES_REQUIRED]: ['N', 'L', 'H'],
@@ -32,3 +70,70 @@ export const baseMetricValues: Record<BaseMetric, BaseMetricValue[]> = {
   [BaseMetric.INTEGRITY]: ['N', 'L', 'H'],
   [BaseMetric.AVAILABILITY]: ['N', 'L', 'H']
 };
+
+export const environmentalMetricValues: MetricValues<
+  EnvironmentalMetric,
+  EnvironmentalMetricValue
+> = {
+  [EnvironmentalMetric.ATTACK_VECTOR]: ['N', 'A', 'L', 'P', 'X'],
+  [EnvironmentalMetric.ATTACK_COMPLEXITY]: ['L', 'H', 'X'],
+  [EnvironmentalMetric.PRIVILEGES_REQUIRED]: ['N', 'L', 'H', 'X'],
+  [EnvironmentalMetric.USER_INTERACTION]: ['N', 'R', 'X'],
+  [EnvironmentalMetric.SCOPE]: ['U', 'C', 'X'],
+  [EnvironmentalMetric.CONFIDENTIALITY]: ['N', 'L', 'H', 'X'],
+  [EnvironmentalMetric.INTEGRITY]: ['N', 'L', 'H', 'X'],
+  [EnvironmentalMetric.AVAILABILITY]: ['N', 'L', 'H', 'X'],
+  [EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT]: ['M', 'L', 'H', 'X'],
+  [EnvironmentalMetric.INTEGRITY_REQUIREMENT]: ['M', 'L', 'H', 'X'],
+  [EnvironmentalMetric.AVAILABILITY_REQUIREMENT]: ['M', 'L', 'H', 'X']
+};
+
+export const temporalMetricValues: MetricValues<
+  TemporalMetric,
+  TemporalMetricValue
+> = {
+  [TemporalMetric.EXPLOITABILITY]: ['X', 'U', 'P', 'F', 'H'],
+  [TemporalMetric.REMEDIATION_LEVEL]: ['X', 'O', 'T', 'W', 'U'],
+  [TemporalMetric.REPORT_CONFIDENCE]: ['X', 'U', 'R', 'C']
+};
+
+export const metricsIndex: { [key: string]: BaseMetric } = {
+  MAV: BaseMetric.ATTACK_VECTOR,
+  MAC: BaseMetric.ATTACK_COMPLEXITY,
+  MPR: BaseMetric.PRIVILEGES_REQUIRED,
+  MUI: BaseMetric.USER_INTERACTION,
+  MS: BaseMetric.SCOPE,
+  MC: BaseMetric.CONFIDENTIALITY,
+  MI: BaseMetric.INTEGRITY,
+  MA: BaseMetric.AVAILABILITY
+};
+
+export type Metric = BaseMetric | TemporalMetric | EnvironmentalMetric;
+export type AnyMetric = BaseMetric & TemporalMetric & EnvironmentalMetric;
+export type BaseMetricValue = 'A' | 'C' | 'H' | 'L' | 'N' | 'P' | 'R' | 'U';
+export type TemporalMetricValue =
+  | 'X'
+  | 'F'
+  | 'H'
+  | 'O'
+  | 'T'
+  | 'W'
+  | 'U'
+  | 'P'
+  | 'C'
+  | 'R';
+export type EnvironmentalMetricValue = BaseMetricValue | 'M' | 'X';
+export type MetricValue =
+  | BaseMetricValue
+  | TemporalMetricValue
+  | EnvironmentalMetricValue
+  | any;
+export type MetricValues<
+  M extends Metric = Metric,
+  V extends MetricValue = MetricValue
+> = Record<M, V[]>;
+export type Metrics<M = Metric> = ReadonlyArray<M>;
+export type AllMetricValues =
+  | typeof baseMetricValues
+  | typeof temporalMetricValues
+  | typeof environmentalMetricValues;

--- a/src/models.ts
+++ b/src/models.ts
@@ -10,23 +10,23 @@ export enum BaseMetric {
 }
 
 export enum TemporalMetric {
-  EXPLOITABILITY = 'E',
+  EXPLOIT_CODE_MATURITY = 'E',
   REMEDIATION_LEVEL = 'RL',
   REPORT_CONFIDENCE = 'RC'
 }
 
 export enum EnvironmentalMetric {
-  ATTACK_VECTOR = 'MAV',
-  ATTACK_COMPLEXITY = 'MAC',
-  PRIVILEGES_REQUIRED = 'MPR',
-  USER_INTERACTION = 'MUI',
-  SCOPE = 'MS',
-  CONFIDENTIALITY = 'MC',
-  INTEGRITY = 'MI',
-  AVAILABILITY = 'MA',
   CONFIDENTIALITY_REQUIREMENT = 'CR',
   INTEGRITY_REQUIREMENT = 'IR',
-  AVAILABILITY_REQUIREMENT = 'AR'
+  AVAILABILITY_REQUIREMENT = 'AR',
+  MODIFIED_ATTACK_VECTOR = 'MAV',
+  MODIFIED_ATTACK_COMPLEXITY = 'MAC',
+  MODIFIED_PRIVILEGES_REQUIRED = 'MPR',
+  MODIFIED_USER_INTERACTION = 'MUI',
+  MODIFIED_SCOPE = 'MS',
+  MODIFIED_CONFIDENTIALITY = 'MC',
+  MODIFIED_INTEGRITY = 'MI',
+  MODIFIED_AVAILABILITY = 'MA'
 }
 
 export const baseMetricMap: ReadonlyArray<BaseMetric> = [
@@ -41,23 +41,23 @@ export const baseMetricMap: ReadonlyArray<BaseMetric> = [
 ];
 
 export const temporalMetricMap: Metrics<TemporalMetric> = [
-  TemporalMetric.EXPLOITABILITY,
+  TemporalMetric.EXPLOIT_CODE_MATURITY,
   TemporalMetric.REMEDIATION_LEVEL,
   TemporalMetric.REPORT_CONFIDENCE
 ];
 
 export const environmentalMetricMap: Metrics<EnvironmentalMetric> = [
-  EnvironmentalMetric.ATTACK_VECTOR,
-  EnvironmentalMetric.ATTACK_COMPLEXITY,
-  EnvironmentalMetric.PRIVILEGES_REQUIRED,
-  EnvironmentalMetric.USER_INTERACTION,
-  EnvironmentalMetric.SCOPE,
-  EnvironmentalMetric.CONFIDENTIALITY,
-  EnvironmentalMetric.INTEGRITY,
-  EnvironmentalMetric.AVAILABILITY,
   EnvironmentalMetric.AVAILABILITY_REQUIREMENT,
   EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT,
-  EnvironmentalMetric.INTEGRITY_REQUIREMENT
+  EnvironmentalMetric.INTEGRITY_REQUIREMENT,
+  EnvironmentalMetric.MODIFIED_ATTACK_VECTOR,
+  EnvironmentalMetric.MODIFIED_ATTACK_COMPLEXITY,
+  EnvironmentalMetric.MODIFIED_PRIVILEGES_REQUIRED,
+  EnvironmentalMetric.MODIFIED_USER_INTERACTION,
+  EnvironmentalMetric.MODIFIED_SCOPE,
+  EnvironmentalMetric.MODIFIED_CONFIDENTIALITY,
+  EnvironmentalMetric.MODIFIED_INTEGRITY,
+  EnvironmentalMetric.MODIFIED_AVAILABILITY
 ];
 
 export const baseMetricValues: MetricValues<BaseMetric, BaseMetricValue> = {
@@ -71,45 +71,33 @@ export const baseMetricValues: MetricValues<BaseMetric, BaseMetricValue> = {
   [BaseMetric.AVAILABILITY]: ['N', 'L', 'H']
 };
 
-export const environmentalMetricValues: MetricValues<
-  EnvironmentalMetric,
-  EnvironmentalMetricValue
-> = {
-  [EnvironmentalMetric.ATTACK_VECTOR]: ['N', 'A', 'L', 'P', 'X'],
-  [EnvironmentalMetric.ATTACK_COMPLEXITY]: ['L', 'H', 'X'],
-  [EnvironmentalMetric.PRIVILEGES_REQUIRED]: ['N', 'L', 'H', 'X'],
-  [EnvironmentalMetric.USER_INTERACTION]: ['N', 'R', 'X'],
-  [EnvironmentalMetric.SCOPE]: ['U', 'C', 'X'],
-  [EnvironmentalMetric.CONFIDENTIALITY]: ['N', 'L', 'H', 'X'],
-  [EnvironmentalMetric.INTEGRITY]: ['N', 'L', 'H', 'X'],
-  [EnvironmentalMetric.AVAILABILITY]: ['N', 'L', 'H', 'X'],
-  [EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT]: ['M', 'L', 'H', 'X'],
-  [EnvironmentalMetric.INTEGRITY_REQUIREMENT]: ['M', 'L', 'H', 'X'],
-  [EnvironmentalMetric.AVAILABILITY_REQUIREMENT]: ['M', 'L', 'H', 'X']
-};
-
 export const temporalMetricValues: MetricValues<
   TemporalMetric,
   TemporalMetricValue
 > = {
-  [TemporalMetric.EXPLOITABILITY]: ['X', 'U', 'P', 'F', 'H'],
-  [TemporalMetric.REMEDIATION_LEVEL]: ['X', 'O', 'T', 'W', 'U'],
-  [TemporalMetric.REPORT_CONFIDENCE]: ['X', 'U', 'R', 'C']
+  [TemporalMetric.EXPLOIT_CODE_MATURITY]: ['X', 'H', 'F', 'P', 'U'],
+  [TemporalMetric.REMEDIATION_LEVEL]: ['X', 'U', 'W', 'T', 'O'],
+  [TemporalMetric.REPORT_CONFIDENCE]: ['X', 'C', 'R', 'U']
 };
 
-export const metricsIndex: { [key: string]: BaseMetric } = {
-  MAV: BaseMetric.ATTACK_VECTOR,
-  MAC: BaseMetric.ATTACK_COMPLEXITY,
-  MPR: BaseMetric.PRIVILEGES_REQUIRED,
-  MUI: BaseMetric.USER_INTERACTION,
-  MS: BaseMetric.SCOPE,
-  MC: BaseMetric.CONFIDENTIALITY,
-  MI: BaseMetric.INTEGRITY,
-  MA: BaseMetric.AVAILABILITY
+export const environmentalMetricValues: MetricValues<
+  EnvironmentalMetric,
+  EnvironmentalMetricValue
+> = {
+  [EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT]: ['X', 'H', 'M', 'L'],
+  [EnvironmentalMetric.INTEGRITY_REQUIREMENT]: ['X', 'H', 'M', 'L'],
+  [EnvironmentalMetric.AVAILABILITY_REQUIREMENT]: ['X', 'H', 'M', 'L'],
+  [EnvironmentalMetric.MODIFIED_ATTACK_VECTOR]: ['X', 'N', 'A', 'L', 'P'],
+  [EnvironmentalMetric.MODIFIED_ATTACK_COMPLEXITY]: ['X', 'L', 'H'],
+  [EnvironmentalMetric.MODIFIED_PRIVILEGES_REQUIRED]: ['X', 'N', 'L', 'H'],
+  [EnvironmentalMetric.MODIFIED_USER_INTERACTION]: ['X', 'N', 'R'],
+  [EnvironmentalMetric.MODIFIED_SCOPE]: ['X', 'U', 'C'],
+  [EnvironmentalMetric.MODIFIED_CONFIDENTIALITY]: ['X', 'N', 'L', 'H'],
+  [EnvironmentalMetric.MODIFIED_INTEGRITY]: ['X', 'N', 'L', 'H'],
+  [EnvironmentalMetric.MODIFIED_AVAILABILITY]: ['X', 'N', 'L', 'H']
 };
 
 export type Metric = BaseMetric | TemporalMetric | EnvironmentalMetric;
-export type AnyMetric = BaseMetric & TemporalMetric & EnvironmentalMetric;
 export type BaseMetricValue = 'A' | 'C' | 'H' | 'L' | 'N' | 'P' | 'R' | 'U';
 export type TemporalMetricValue =
   | 'X'
@@ -126,8 +114,7 @@ export type EnvironmentalMetricValue = BaseMetricValue | 'M' | 'X';
 export type MetricValue =
   | BaseMetricValue
   | TemporalMetricValue
-  | EnvironmentalMetricValue
-  | any;
+  | EnvironmentalMetricValue;
 export type MetricValues<
   M extends Metric = Metric,
   V extends MetricValue = MetricValue

--- a/src/models.ts
+++ b/src/models.ts
@@ -29,7 +29,7 @@ export enum EnvironmentalMetric {
   MODIFIED_AVAILABILITY = 'MA'
 }
 
-export const baseMetricMap: ReadonlyArray<BaseMetric> = [
+export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.ATTACK_VECTOR,
   BaseMetric.ATTACK_COMPLEXITY,
   BaseMetric.PRIVILEGES_REQUIRED,
@@ -40,13 +40,13 @@ export const baseMetricMap: ReadonlyArray<BaseMetric> = [
   BaseMetric.AVAILABILITY
 ];
 
-export const temporalMetricMap: Metrics<TemporalMetric> = [
+export const temporalMetrics: Metrics<TemporalMetric> = [
   TemporalMetric.EXPLOIT_CODE_MATURITY,
   TemporalMetric.REMEDIATION_LEVEL,
   TemporalMetric.REPORT_CONFIDENCE
 ];
 
-export const environmentalMetricMap: Metrics<EnvironmentalMetric> = [
+export const environmentalMetrics: Metrics<EnvironmentalMetric> = [
   EnvironmentalMetric.AVAILABILITY_REQUIREMENT,
   EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT,
   EnvironmentalMetric.INTEGRITY_REQUIREMENT,

--- a/src/models.ts
+++ b/src/models.ts
@@ -60,7 +60,7 @@ export const environmentalMetrics: Metrics<EnvironmentalMetric> = [
   EnvironmentalMetric.INTEGRITY_REQUIREMENT
 ];
 
-export const baseMetricValues: MetricValues<BaseMetric, BaseMetricValue[]> = {
+export const baseMetricValues: MetricValues<BaseMetric, BaseMetricValue> = {
   [BaseMetric.ATTACK_VECTOR]: ['N', 'A', 'L', 'P'],
   [BaseMetric.ATTACK_COMPLEXITY]: ['L', 'H'],
   [BaseMetric.PRIVILEGES_REQUIRED]: ['N', 'L', 'H'],
@@ -137,3 +137,10 @@ export type AllMetricValues =
   | typeof baseMetricValues
   | typeof temporalMetricValues
   | typeof environmentalMetricValues;
+
+export type ScoreResult = {
+  score: number;
+  impact: number;
+  exploitability: number;
+  metricsMap: Map<Metric, MetricValue>;
+};

--- a/src/models.ts
+++ b/src/models.ts
@@ -29,7 +29,7 @@ export enum EnvironmentalMetric {
   AVAILABILITY_REQUIREMENT = 'AR'
 }
 
-export const baseMetrics: ReadonlyArray<BaseMetric> = [
+export const baseMetricMap: ReadonlyArray<BaseMetric> = [
   BaseMetric.ATTACK_VECTOR,
   BaseMetric.ATTACK_COMPLEXITY,
   BaseMetric.PRIVILEGES_REQUIRED,
@@ -40,13 +40,13 @@ export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.AVAILABILITY
 ];
 
-export const temporalMetrics: Metrics<TemporalMetric> = [
+export const temporalMetricMap: Metrics<TemporalMetric> = [
   TemporalMetric.EXPLOITABILITY,
   TemporalMetric.REMEDIATION_LEVEL,
   TemporalMetric.REPORT_CONFIDENCE
 ];
 
-export const environmentalMetrics: Metrics<EnvironmentalMetric> = [
+export const environmentalMetricMap: Metrics<EnvironmentalMetric> = [
   EnvironmentalMetric.ATTACK_VECTOR,
   EnvironmentalMetric.ATTACK_COMPLEXITY,
   EnvironmentalMetric.PRIVILEGES_REQUIRED,

--- a/src/models.ts
+++ b/src/models.ts
@@ -137,10 +137,3 @@ export type AllMetricValues =
   | typeof baseMetricValues
   | typeof temporalMetricValues
   | typeof environmentalMetricValues;
-
-export type ScoreResult = {
-  score: number;
-  impact: number;
-  exploitability: number;
-  metricsMap: Map<Metric, MetricValue>;
-};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { BaseMetric, BaseMetricValue } from './models';
+import { BaseMetric, BaseMetricValue, Metric, MetricValue } from './models';
 
 export interface KeyValue<K, V> {
   key: K;
@@ -30,9 +30,7 @@ export const parseMetrics = (vectorStr: string): KeyValue<string, string>[] =>
     return { key: parts[0], value: parts[1] };
   });
 
-export const parseMetricsAsMap = (
-  cvssStr: string
-): Map<BaseMetric, BaseMetricValue> =>
+export const parseMetricsAsMap = (cvssStr: string): Map<Metric, MetricValue> =>
   parseMetrics(parseVector(cvssStr) || '').reduce(
     (
       res: Map<BaseMetric, BaseMetricValue>,

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -1,5 +1,18 @@
-import { BaseMetric, BaseMetricValue } from './models';
-import { parseMetricsAsMap } from './parser';
+import {
+  AnyMetric,
+  BaseMetric,
+  BaseMetricValue,
+  EnvironmentalMetric,
+  environmentalMetrics,
+  EnvironmentalMetricValue,
+  Metric,
+  MetricValue,
+  metricsIndex,
+  ScoreResult,
+  TemporalMetric,
+  temporalMetrics,
+  TemporalMetricValue
+} from './models';
 import { validate } from './validator';
 
 // https://www.first.org/cvss/v3.1/specification-document#7-4-Metric-Values
@@ -17,9 +30,45 @@ const baseMetricValueScores: Record<
   [BaseMetric.AVAILABILITY]: { N: 0, L: 0.22, H: 0.56 }
 };
 
+const temporalMetricValueScores: Record<
+  TemporalMetric,
+  Partial<Record<TemporalMetricValue, number>> | null
+> = {
+  [TemporalMetric.EXPLOITABILITY]: { X: 1, U: 0.91, F: 0.97, P: 0.94, H: 1 },
+  [TemporalMetric.REMEDIATION_LEVEL]: { X: 1, O: 0.95, T: 0.96, W: 0.97, U: 1 },
+  [TemporalMetric.REPORT_CONFIDENCE]: { X: 1, U: 0.92, R: 0.96, C: 1 }
+};
+
+const environmentalMetricValueScores: Record<
+  EnvironmentalMetric,
+  Partial<Record<EnvironmentalMetricValue, number>> | null
+> = {
+  [EnvironmentalMetric.ATTACK_VECTOR]:
+    baseMetricValueScores[BaseMetric.ATTACK_VECTOR],
+  [EnvironmentalMetric.ATTACK_COMPLEXITY]:
+    baseMetricValueScores[BaseMetric.ATTACK_COMPLEXITY],
+  [EnvironmentalMetric.PRIVILEGES_REQUIRED]: null, // scope-dependent: see getPrivilegesRequiredNumericValue()
+  [EnvironmentalMetric.USER_INTERACTION]:
+    baseMetricValueScores[BaseMetric.USER_INTERACTION],
+  [EnvironmentalMetric.SCOPE]: baseMetricValueScores[BaseMetric.SCOPE],
+  [EnvironmentalMetric.CONFIDENTIALITY]:
+    baseMetricValueScores[BaseMetric.CONFIDENTIALITY],
+  [EnvironmentalMetric.INTEGRITY]: baseMetricValueScores[BaseMetric.INTEGRITY],
+  [EnvironmentalMetric.AVAILABILITY]:
+    baseMetricValueScores[BaseMetric.AVAILABILITY],
+  [EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT]: {
+    M: 1,
+    L: 0.5,
+    H: 1.5,
+    X: 1
+  },
+  [EnvironmentalMetric.INTEGRITY_REQUIREMENT]: { M: 1, L: 0.5, H: 1.5, X: 1 },
+  [EnvironmentalMetric.AVAILABILITY_REQUIREMENT]: { M: 1, L: 0.5, H: 1.5, X: 1 }
+};
+
 const getPrivilegesRequiredNumericValue = (
-  value: BaseMetricValue,
-  scopeValue: BaseMetricValue
+  value: MetricValue,
+  scopeValue: MetricValue
 ): number => {
   if (scopeValue !== 'U' && scopeValue !== 'C') {
     throw new Error(`Unknown Scope value: ${scopeValue}`);
@@ -38,9 +87,9 @@ const getPrivilegesRequiredNumericValue = (
 };
 
 const getMetricValue = (
-  metric: BaseMetric,
-  metricsMap: Map<BaseMetric, BaseMetricValue>
-): BaseMetricValue => {
+  metric: Metric,
+  metricsMap: Map<Metric, MetricValue>
+): MetricValue => {
   if (!metricsMap.has(metric)) {
     throw new Error(`Missing metric: ${metric}`);
   }
@@ -49,20 +98,30 @@ const getMetricValue = (
 };
 
 const getMetricNumericValue = (
-  metric: BaseMetric,
-  metricsMap: Map<BaseMetric, BaseMetricValue>
+  metric: Metric,
+  metricsMap: Map<Metric, MetricValue>
 ): number => {
-  const value = getMetricValue(metric, metricsMap);
+  const value = getMetricValue(metric as AnyMetric, metricsMap);
 
   if (metric === BaseMetric.PRIVILEGES_REQUIRED) {
     return getPrivilegesRequiredNumericValue(
       value,
-      getMetricValue(BaseMetric.SCOPE, metricsMap)
+      getMetricValue(BaseMetric.SCOPE as AnyMetric, metricsMap)
+    );
+  }
+  if (metric === EnvironmentalMetric.PRIVILEGES_REQUIRED) {
+    return getPrivilegesRequiredNumericValue(
+      value,
+      getMetricValue(EnvironmentalMetric.SCOPE as AnyMetric, metricsMap)
     );
   }
 
-  const score: Partial<Record<BaseMetricValue, number>> | null =
-    baseMetricValueScores[metric];
+  const score: Partial<Record<MetricValue, number>> | null = {
+    ...baseMetricValueScores,
+    ...temporalMetricValueScores,
+    ...environmentalMetricValueScores
+  }[metric];
+
   if (!score) {
     throw new Error(`Internal error. Missing metric score: ${metric}`);
   }
@@ -71,9 +130,7 @@ const getMetricNumericValue = (
 };
 
 // ISS = 1 - [ (1 - Confidentiality) × (1 - Integrity) × (1 - Availability) ]
-export const calculateIss = (
-  metricsMap: Map<BaseMetric, BaseMetricValue>
-): number => {
+export const calculateIss = (metricsMap: Map<Metric, MetricValue>): number => {
   const confidentiality = getMetricNumericValue(
     BaseMetric.CONFIDENTIALITY,
     metricsMap
@@ -87,28 +144,94 @@ export const calculateIss = (
   return 1 - (1 - confidentiality) * (1 - integrity) * (1 - availability);
 };
 
+// https://www.first.org/cvss/v3.1/specification-document#7-3-Environmental-Metrics-Equations
+// MISS = Minimum ( 1 - [ (1 - ConfidentialityRequirement × ModifiedConfidentiality) × (1 - IntegrityRequirement × ModifiedIntegrity) × (1 - AvailabilityRequirement × ModifiedAvailability) ], 0.915)
+export const calculateMiss = (metricsMap: Map<Metric, MetricValue>): number => {
+  const rConfidentiality = getMetricNumericValue(
+    EnvironmentalMetric.CONFIDENTIALITY_REQUIREMENT,
+    metricsMap
+  );
+  const mConfidentiality = getMetricNumericValue(
+    EnvironmentalMetric.CONFIDENTIALITY,
+    metricsMap
+  );
+
+  const rIntegrity = getMetricNumericValue(
+    EnvironmentalMetric.INTEGRITY_REQUIREMENT,
+    metricsMap
+  );
+  const mIntegrity = getMetricNumericValue(
+    EnvironmentalMetric.INTEGRITY,
+    metricsMap
+  );
+
+  const rAvailability = getMetricNumericValue(
+    EnvironmentalMetric.AVAILABILITY_REQUIREMENT,
+    metricsMap
+  );
+  const mAvailability = getMetricNumericValue(
+    EnvironmentalMetric.AVAILABILITY,
+    metricsMap
+  );
+
+  return Math.min(
+    1 -
+      (1 - rConfidentiality * mConfidentiality) *
+        (1 - rIntegrity * mIntegrity) *
+        (1 - rAvailability * mAvailability),
+    0.915
+  );
+};
+
 // https://www.first.org/cvss/v3.1/specification-document#7-1-Base-Metrics-Equations
 // Impact =
 //   If Scope is Unchanged 	6.42 × ISS
 //   If Scope is Changed 	7.52 × (ISS - 0.029) - 3.25 × (ISS - 0.02)
 export const calculateImpact = (
-  metricsMap: Map<BaseMetric, BaseMetricValue>,
+  metricsMap: Map<Metric, MetricValue>,
   iss: number
 ): number =>
   metricsMap.get(BaseMetric.SCOPE) === 'U'
     ? 6.42 * iss
     : 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15);
 
+// https://www.first.org/cvss/v3.1/specification-document#7-3-Environmental-Metrics-Equations
+// ModifiedImpact =
+// If ModifiedScope is Unchanged	6.42 × MISS
+// If ModifiedScope is Changed	7.52 × (MISS - 0.029) - 3.25 × (MISS × 0.9731 - 0.02)13
+// ModifiedExploitability =	8.22 × ModifiedAttackVector × ModifiedAttackComplexity × ModifiedPrivilegesRequired × ModifiedUserInteraction
+// Note : Math.pow is 15 in 3.0 but 13 int 3.1
+export const calculateMImpact = (
+  metricsMap: Map<Metric, MetricValue>,
+  miss: number,
+  versionStr: string | null
+): number =>
+  metricsMap.get(EnvironmentalMetric.SCOPE) === 'U'
+    ? 6.42 * miss
+    : 7.52 * (miss - 0.029) -
+      3.25 * Math.pow(miss * 0.9731 - 0.02, versionStr === '3.0' ? 15 : 13);
+
 // https://www.first.org/cvss/v3.1/specification-document#7-1-Base-Metrics-Equations
 // Exploitability = 8.22 × AttackVector × AttackComplexity × PrivilegesRequired × UserInteraction
 export const calculateExploitability = (
-  metricsMap: Map<BaseMetric, BaseMetricValue>
+  metricsMap: Map<Metric, MetricValue>
 ): number =>
   8.22 *
   getMetricNumericValue(BaseMetric.ATTACK_VECTOR, metricsMap) *
   getMetricNumericValue(BaseMetric.ATTACK_COMPLEXITY, metricsMap) *
   getMetricNumericValue(BaseMetric.PRIVILEGES_REQUIRED, metricsMap) *
   getMetricNumericValue(BaseMetric.USER_INTERACTION, metricsMap);
+
+// https://www.first.org/cvss/v3.1/specification-document#7-3-Environmental-Metrics-Equations
+// Exploitability = 8.22 × ModifiedAttackVector × ModifiedAttackComplexity × ModifiedPrivilegesRequired × ModifiedUserInteraction
+export const calculateMExploitability = (
+  metricsMap: Map<Metric, MetricValue>
+): number =>
+  8.22 *
+  getMetricNumericValue(EnvironmentalMetric.ATTACK_VECTOR, metricsMap) *
+  getMetricNumericValue(EnvironmentalMetric.ATTACK_COMPLEXITY, metricsMap) *
+  getMetricNumericValue(EnvironmentalMetric.PRIVILEGES_REQUIRED, metricsMap) *
+  getMetricNumericValue(EnvironmentalMetric.USER_INTERACTION, metricsMap);
 
 // https://www.first.org/cvss/v3.1/specification-document#Appendix-A---Floating-Point-Rounding
 const roundUp = (input: number): number => {
@@ -119,24 +242,128 @@ const roundUp = (input: number): number => {
     : (Math.floor(intInput / 10000) + 1) / 10;
 };
 
+// populate temp and env metrics if not provided
+export const populateUndefinedMetrics = (
+  metricsMap: Map<Metric, MetricValue>
+): Map<Metric, MetricValue> => {
+  [...temporalMetrics, ...environmentalMetrics].map((metric) => {
+    if (![...metricsMap.keys()].includes(metric)) {
+      metricsMap.set(
+        metric,
+        metricsIndex[metric] ? metricsMap.get(metricsIndex[metric]) : 'X'
+      );
+    }
+    if (metricsMap.get(metric) === 'X') {
+      metricsMap.set(
+        metric,
+        metricsMap.get(metricsIndex[metric])
+          ? metricsMap.get(metricsIndex[metric])
+          : 'X'
+      );
+    }
+  });
+
+  return metricsMap;
+};
+
+// https://www.first.org/cvss/v3.1/specification-document#7-3-Environmental-Metrics-Equations
+// If ModifiedImpact <= 0 =>	0; else
+// If ModifiedScope is Unchanged =>	Roundup (Roundup [Minimum ([ModifiedImpact + ModifiedExploitability], 10)] × ExploitCodeMaturity × RemediationLevel × ReportConfidence)
+// If ModifiedScope is Changed =>	Roundup (Roundup [Minimum (1.08 × [ModifiedImpact + ModifiedExploitability], 10)] × ExploitCodeMaturity × RemediationLevel × ReportConfidence)
+export const calculateEnvironmentalScore = (
+  cvssString: string
+): ScoreResult => {
+  const { versionStr } = validate(cvssString);
+  let { metricsMap } = validate(cvssString);
+
+  metricsMap = populateUndefinedMetrics(metricsMap);
+  const miss = calculateMiss(metricsMap);
+  const impact = calculateMImpact(metricsMap, miss, versionStr);
+  const exploitability = calculateMExploitability(metricsMap);
+  const scopeUnchanged = metricsMap.get(EnvironmentalMetric.SCOPE) === 'U';
+
+  const score =
+    impact <= 0
+      ? 0
+      : scopeUnchanged
+      ? roundUp(
+          roundUp(Math.min(impact + exploitability, 10)) *
+            getMetricNumericValue(TemporalMetric.EXPLOITABILITY, metricsMap) *
+            getMetricNumericValue(
+              TemporalMetric.REMEDIATION_LEVEL,
+              metricsMap
+            ) *
+            getMetricNumericValue(TemporalMetric.REPORT_CONFIDENCE, metricsMap)
+        )
+      : roundUp(
+          roundUp(Math.min(1.08 * (impact + exploitability), 10)) *
+            getMetricNumericValue(TemporalMetric.EXPLOITABILITY, metricsMap) *
+            getMetricNumericValue(
+              TemporalMetric.REMEDIATION_LEVEL,
+              metricsMap
+            ) *
+            getMetricNumericValue(TemporalMetric.REPORT_CONFIDENCE, metricsMap)
+        );
+
+  return {
+    score,
+    metricsMap,
+    impact: impact <= 0 ? 0 : roundUp(impact),
+    exploitability: impact <= 0 ? 0 : roundUp(exploitability)
+  };
+};
+
 // https://www.first.org/cvss/v3.1/specification-document#7-1-Base-Metrics-Equations
 // If Impact <= 0 => 0; else
 // If Scope is Unchanged => Roundup (Minimum [(Impact + Exploitability), 10])
 // If Scope is Changed => Roundup (Minimum [1.08 × (Impact + Exploitability), 10])
-export const calculateBaseScore = (cvssString: string): number => {
-  validate(cvssString);
+export const calculateBaseScore = (cvssString: string): ScoreResult => {
+  const { metricsMap } = validate(cvssString);
 
-  const metricsMap: Map<BaseMetric, BaseMetricValue> = parseMetricsAsMap(
-    cvssString
-  );
   const iss = calculateIss(metricsMap);
   const impact = calculateImpact(metricsMap, iss);
   const exploitability = calculateExploitability(metricsMap);
   const scopeUnchanged = metricsMap.get(BaseMetric.SCOPE) === 'U';
 
-  return impact <= 0
-    ? 0
-    : scopeUnchanged
-    ? roundUp(Math.min(impact + exploitability, 10))
-    : roundUp(Math.min(1.08 * (impact + exploitability), 10));
+  const score =
+    impact <= 0
+      ? 0
+      : scopeUnchanged
+      ? roundUp(Math.min(impact + exploitability, 10))
+      : roundUp(Math.min(1.08 * (impact + exploitability), 10));
+
+  return {
+    score,
+    metricsMap,
+    impact: impact <= 0 ? 0 : roundUp(impact),
+    exploitability: impact <= 0 ? 0 : roundUp(exploitability)
+  };
+};
+
+// https://www.first.org/cvss/v3.1/specification-document#7-2-Temporal-Metrics-Equations
+// 	Roundup (BaseScore × ExploitCodeMaturity × RemediationLevel × ReportConfidence)
+export const calculateTemporalScore = (cvssString: string): ScoreResult => {
+  const { metricsMap } = validate(cvssString);
+  // populate temp metrics if not provided
+  [...temporalMetrics].map((metric) => {
+    if (![...metricsMap.keys()].includes(metric)) {
+      metricsMap.set(metric, 'X');
+    }
+  });
+
+  const { score, impact, exploitability } = calculateBaseScore(cvssString);
+
+  const tempScore = roundUp(
+    score *
+      getMetricNumericValue(TemporalMetric.REPORT_CONFIDENCE, metricsMap) *
+      getMetricNumericValue(TemporalMetric.EXPLOITABILITY, metricsMap) *
+      getMetricNumericValue(TemporalMetric.REMEDIATION_LEVEL, metricsMap)
+  );
+
+  return {
+    score: tempScore,
+    metricsMap,
+    impact,
+    exploitability
+  };
 };

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -3,14 +3,14 @@ import {
   BaseMetric,
   BaseMetricValue,
   EnvironmentalMetric,
-  environmentalMetrics,
+  environmentalMetricMap,
   EnvironmentalMetricValue,
   Metric,
   MetricValue,
   metricsIndex,
   ScoreResult,
   TemporalMetric,
-  temporalMetrics,
+  temporalMetricMap,
   TemporalMetricValue
 } from './models';
 import { validate } from './validator';
@@ -200,7 +200,7 @@ export const calculateImpact = (
 // If ModifiedScope is Unchanged	6.42 × MISS
 // If ModifiedScope is Changed	7.52 × (MISS - 0.029) - 3.25 × (MISS × 0.9731 - 0.02)13
 // ModifiedExploitability =	8.22 × ModifiedAttackVector × ModifiedAttackComplexity × ModifiedPrivilegesRequired × ModifiedUserInteraction
-// Note : Math.pow is 15 in 3.0 but 13 int 3.1
+// Note : Math.pow is 15 in 3.0 but 13 in 3.1
 export const calculateMImpact = (
   metricsMap: Map<Metric, MetricValue>,
   miss: number,
@@ -246,7 +246,7 @@ const roundUp = (input: number): number => {
 export const populateUndefinedMetrics = (
   metricsMap: Map<Metric, MetricValue>
 ): Map<Metric, MetricValue> => {
-  [...temporalMetrics, ...environmentalMetrics].map((metric) => {
+  [...temporalMetricMap, ...environmentalMetricMap].map((metric) => {
     if (![...metricsMap.keys()].includes(metric)) {
       metricsMap.set(
         metric,
@@ -345,7 +345,7 @@ export const calculateBaseScore = (cvssString: string): ScoreResult => {
 export const calculateTemporalScore = (cvssString: string): ScoreResult => {
   const { metricsMap } = validate(cvssString);
   // populate temp metrics if not provided
-  [...temporalMetrics].map((metric) => {
+  [...temporalMetricMap].map((metric) => {
     if (![...metricsMap.keys()].includes(metric)) {
       metricsMap.set(metric, 'X');
     }

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -2,12 +2,12 @@ import {
   BaseMetric,
   BaseMetricValue,
   EnvironmentalMetric,
-  environmentalMetricMap,
+  environmentalMetrics,
   EnvironmentalMetricValue,
   Metric,
   MetricValue,
   TemporalMetric,
-  temporalMetricMap,
+  temporalMetrics,
   TemporalMetricValue
 } from './models';
 import { validate } from './validator';
@@ -285,7 +285,7 @@ export const modifiedMetricsMap: { [key: string]: BaseMetric } = {
 export const populateTemporalMetricDefaults = (
   metricsMap: Map<Metric, MetricValue>
 ): Map<Metric, MetricValue> => {
-  [...temporalMetricMap].forEach((metric) => {
+  [...temporalMetrics].forEach((metric) => {
     if (!metricsMap.has(metric)) {
       metricsMap.set(metric, 'X');
     }
@@ -297,7 +297,7 @@ export const populateTemporalMetricDefaults = (
 export const populateEnvironmentalMetricDefaults = (
   metricsMap: Map<Metric, MetricValue>
 ): Map<Metric, MetricValue> => {
-  [...environmentalMetricMap].forEach((metric: EnvironmentalMetric) => {
+  [...environmentalMetrics].forEach((metric: EnvironmentalMetric) => {
     if (!metricsMap.has(metric)) {
       metricsMap.set(metric, 'X');
     }
@@ -421,7 +421,7 @@ export const calculateEnvironmentalScore = (cvssString: string): number => {
 export const calculateTemporalResult = (cvssString: string): ScoreResult => {
   const { metricsMap } = validate(cvssString);
   // populate temp metrics if not provided
-  [...temporalMetricMap].map((metric) => {
+  [...temporalMetrics].map((metric) => {
     if (![...metricsMap.keys()].includes(metric)) {
       metricsMap.set(metric, 'X');
     }

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -8,7 +8,6 @@ import {
   Metric,
   MetricValue,
   metricsIndex,
-  ScoreResult,
   TemporalMetric,
   temporalMetricMap,
   TemporalMetricValue
@@ -264,6 +263,13 @@ export const populateUndefinedMetrics = (
   });
 
   return metricsMap;
+};
+
+export type ScoreResult = {
+  score: number;
+  impact: number;
+  exploitability: number;
+  metricsMap: Map<Metric, MetricValue>;
 };
 
 // https://www.first.org/cvss/v3.1/specification-document#7-3-Environmental-Metrics-Equations

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,9 +2,9 @@ import {
   Metric,
   MetricValue,
   Metrics,
-  baseMetrics,
-  temporalMetrics,
-  environmentalMetrics,
+  baseMetricMap,
+  temporalMetricMap,
+  environmentalMetricMap,
   AllMetricValues,
   baseMetricValues,
   temporalMetricValues,
@@ -42,9 +42,9 @@ const checkUnknownMetrics = (
   knownMetrics?: Metrics
 ): void => {
   const allKnownMetrics = knownMetrics || [
-    ...baseMetrics,
-    ...temporalMetrics,
-    ...environmentalMetrics
+    ...baseMetricMap,
+    ...temporalMetricMap,
+    ...environmentalMetricMap
   ];
 
   [...metricsMap.keys()].forEach((userMetric: string) => {
@@ -60,7 +60,7 @@ const checkUnknownMetrics = (
 
 const checkMandatoryMetrics = (
   metricsMap: Map<string, string>,
-  metrics: Metrics = baseMetrics
+  metrics: Metrics = baseMetricMap
 ): void => {
   metrics.forEach((metric: Metric) => {
     if (!metricsMap.has(metric)) {
@@ -118,9 +118,9 @@ export const validate = (cvssStr: string): ValidationResult => {
     throw new Error('CVSS vector must start with "CVSS:"');
   }
   const allKnownMetrics = [
-    ...baseMetrics,
-    ...temporalMetrics,
-    ...environmentalMetrics
+    ...baseMetricMap,
+    ...temporalMetricMap,
+    ...environmentalMetricMap
   ];
   const allKnownMetricsValues = {
     ...baseMetricValues,
@@ -140,10 +140,10 @@ export const validate = (cvssStr: string): ValidationResult => {
   checkMetricsValues(metricsMap, allKnownMetrics, allKnownMetricsValues);
 
   const isTemporal = [...metricsMap.keys()].some((metric) =>
-    temporalMetrics.includes(metric as TemporalMetric)
+    temporalMetricMap.includes(metric as TemporalMetric)
   );
   const isEnvironmental = [...metricsMap.keys()].some((metric) =>
-    environmentalMetrics.includes(metric as EnvironmentalMetric)
+    environmentalMetricMap.includes(metric as EnvironmentalMetric)
   );
 
   return {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,9 +2,9 @@ import {
   Metric,
   MetricValue,
   Metrics,
-  baseMetricMap,
-  temporalMetricMap,
-  environmentalMetricMap,
+  baseMetrics,
+  temporalMetrics,
+  environmentalMetrics,
   AllMetricValues,
   baseMetricValues,
   temporalMetricValues,
@@ -42,9 +42,9 @@ const checkUnknownMetrics = (
   knownMetrics?: Metrics
 ): void => {
   const allKnownMetrics = knownMetrics || [
-    ...baseMetricMap,
-    ...temporalMetricMap,
-    ...environmentalMetricMap
+    ...baseMetrics,
+    ...temporalMetrics,
+    ...environmentalMetrics
   ];
 
   [...metricsMap.keys()].forEach((userMetric: string) => {
@@ -60,7 +60,7 @@ const checkUnknownMetrics = (
 
 const checkMandatoryMetrics = (
   metricsMap: Map<string, string>,
-  metrics: Metrics = baseMetricMap
+  metrics: Metrics = baseMetrics
 ): void => {
   metrics.forEach((metric: Metric) => {
     if (!metricsMap.has(metric)) {
@@ -118,9 +118,9 @@ export const validate = (cvssStr: string): ValidationResult => {
     throw new Error('CVSS vector must start with "CVSS:"');
   }
   const allKnownMetrics = [
-    ...baseMetricMap,
-    ...temporalMetricMap,
-    ...environmentalMetricMap
+    ...baseMetrics,
+    ...temporalMetrics,
+    ...environmentalMetrics
   ];
   const allKnownMetricsValues = {
     ...baseMetricValues,
@@ -140,10 +140,10 @@ export const validate = (cvssStr: string): ValidationResult => {
   checkMetricsValues(metricsMap, allKnownMetrics, allKnownMetricsValues);
 
   const isTemporal = [...metricsMap.keys()].some((metric) =>
-    temporalMetricMap.includes(metric as TemporalMetric)
+    temporalMetrics.includes(metric as TemporalMetric)
   );
   const isEnvironmental = [...metricsMap.keys()].some((metric) =>
-    environmentalMetricMap.includes(metric as EnvironmentalMetric)
+    environmentalMetrics.includes(metric as EnvironmentalMetric)
   );
 
   return {

--- a/tests/score-calculator.spec.ts
+++ b/tests/score-calculator.spec.ts
@@ -113,7 +113,7 @@ describe('Calculate correctly base scores', () => {
     const cvss = entry[0];
     const baseScore = entry[1][0];
     it(`should calculate a score of ${baseScore} for ${cvss}`, () => {
-      const { score } = calculateBaseScore(cvss);
+      const score = calculateBaseScore(cvss);
       expect(score).to.equal(baseScore);
     });
   });
@@ -124,7 +124,7 @@ describe('Calculate correctly temporal scores', () => {
     const cvss = entry[0];
     const temporalScore = entry[1][1];
     it(`should calculate a score of ${temporalScore} for ${cvss}`, () => {
-      const { score } = calculateTemporalScore(cvss);
+      const score = calculateTemporalScore(cvss);
       expect(score).to.equal(temporalScore);
     });
   });
@@ -135,7 +135,7 @@ describe('Calculate correctly environmental scores', () => {
     const cvss = entry[0];
     const environmentalScore = entry[1][2];
     it(`should calculate a score of ${environmentalScore} for ${cvss}`, () => {
-      const { score } = calculateEnvironmentalScore(cvss);
+      const score = calculateEnvironmentalScore(cvss);
       expect(score).to.equal(environmentalScore);
     });
   });

--- a/tests/score-calculator.spec.ts
+++ b/tests/score-calculator.spec.ts
@@ -1,59 +1,95 @@
-import { calculateBaseScore } from '../src';
+import {
+  calculateBaseScore,
+  calculateEnvironmentalScore,
+  calculateTemporalScore
+} from '../src';
 import { expect } from 'chai';
 
-describe('calculator', () => {
-  it('should calculate "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N" score as 8.6', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N'
-    );
-    expect(result).to.equal(8.6);
-  });
+// CVSS => base, temporal, environmental
+const cvssTests = {
+  'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N': [8.6, 8.6, 8.6],
+  'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H': [10.0, 10.0, 10.0],
+  'CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N': [0.0, 0.0, 0.0],
+  'CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H': [7.8, 7.8, 7.8], // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
+  'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N': [7.5, 7.5, 7.5], // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
+  'CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N': [6.4, 6.4, 6.4], // https://www.first.org/cvss/user-guide#3-6-Vulnerable-Components-Protected-by-a-Firewall
+  'CVSS:3.1/S:C/C:L/I:L/A:N/AV:N/AC:L/PR:L/UI:N': [6.4, 6.4, 6.4], // non-normalized order
+  'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N': [8.6, 8.6, 8.6],
+  'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H': [10.0, 10.0, 10.0],
+  'CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N': [0.0, 0.0, 0.0],
+  'CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H': [7.8, 7.8, 7.8],
+  'CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:U/RL:O/RC:U/CR:M/IR:M/AR:M/MAV:A/MAC:H/MPR:L/MUI:N/MS:X/MC:N/MI:H/MA:X': [
+    5.1,
+    4.1,
+    5.2
+  ],
+  'CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N/E:U/RL:T/RC:C/CR:X/IR:L/AR:L/MAV:N/MAC:H/MPR:L/MUI:N/MS:U/MC:L/MI:L/MA:L': [
+    4.6,
+    4.1,
+    3.6
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:L/UI:N/S:C/C:L/I:N/A:N/E:P/RL:W/RC:C/IR:L/AR:L/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MI:L/MA:L': [
+    3.0,
+    2.8,
+    4.0
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:U/RL:O/RC:U/CR:H/IR:H/AR:L/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:N/MI:N/MA:N': [
+    5.1,
+    4.1,
+    0.0
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:H/RL:U/RC:C/CR:M/IR:M/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:H/MI:H/MA:H': [
+    5.1,
+    5.1,
+    10.0
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L/CR:M/IR:M/AR:L/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:N/MA:L': [
+    3.8,
+    3.8,
+    2.4
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L/CR:H/IR:M/AR:H/MAV:A/MAC:H/MPR:N/MUI:R/MC:N/MI:H/MA:N': [
+    3.8,
+    3.8,
+    4.8
+  ],
+  'CVSS:3.1/AV:A/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L/CR:H/IR:M/AR:H/MAV:A/MAC:H/MPR:N/MUI:R/MS:C/MC:N/MI:H/MA:N': [
+    3.8,
+    3.8,
+    5.6
+  ],
+  'CVSS:3.1/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L/E:H/RL:U/RC:C/MAV:P/MAC:H/MPR:N/MUI:R/MS:C/MC:L': [
+    6.2,
+    6.2,
+    6.1
+  ],
+  'CVSS:3.0/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L/E:H/RL:U/RC:C/MAV:P/MAC:H/MPR:N/MUI:R/MS:C/MC:L': [
+    6.2,
+    6.2,
+    6.2
+  ],
+  'CVSS:3.0/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L': [6.2, 6.2, 6.2],
+  'CVSS:3.0/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L/CR:H': [6.2, 6.2, 6.4],
+  'CVSS:3.0/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L/CR:H/IR:H/MAV:L/MUI:R/MS:U/MC:L': [
+    6.2,
+    6.2,
+    7.0
+  ],
+  'CVSS:3.1/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L': [6.2, 6.2, 6.1],
+  'CVSS:3.1/AV:P/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L/MUI:R/MS:U/MC:L': [
+    6.2,
+    6.2,
+    5.1
+  ],
+  'CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:U/RL:O/RC:U/CR:M/IR:M/AR:M/MAV:A/MAC:L/MPR:L/MUI:N/MC:N/MI:H': [
+    4.4,
+    3.5,
+    6.1
+  ],
+  'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L': [8.6, 8.2, 6.0]
+};
 
-  it('should calculate "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H" score as 10.0', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H'
-    );
-    expect(result).to.equal(10);
-  });
-
-  it('should calculate "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N" score as 0.0', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N'
-    );
-    expect(result).to.equal(0);
-  });
-
-  // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
-  it('should calculate "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N" score as 7.5', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N'
-    );
-    expect(result).to.equal(7.5);
-  });
-
-  // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
-  it('should calculate "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H" score as 7.8', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H'
-    );
-    expect(result).to.equal(7.8);
-  });
-
-  // https://www.first.org/cvss/user-guide#3-6-Vulnerable-Components-Protected-by-a-Firewall
-  it('should calculate "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N" score as 6.4', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N'
-    );
-    expect(result).to.equal(6.4);
-  });
-
-  it('should calculate "CVSS:3.1/S:C/C:L/I:L/A:N/AV:N/AC:L/PR:L/UI:N" (non-normalized order) score as 6.4', () => {
-    const result = calculateBaseScore(
-      'CVSS:3.1/S:C/C:L/I:L/A:N/AV:N/AC:L/PR:L/UI:N'
-    );
-    expect(result).to.equal(6.4);
-  });
-
+describe('Calculator', () => {
   // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
   it('should throw an exception on empty value', () => {
     expect(() => calculateBaseScore('')).to.throw();
@@ -61,7 +97,7 @@ describe('calculator', () => {
 
   // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
   it('should throw an exception on missing metric', () => {
-    expect(() => calculateBaseScore('CVSS:3.0/A:H')).to.throw();
+    expect(() => calculateBaseScore('CVSS:3.1/A:H')).to.throw();
   });
 
   // https://www.first.org/cvss/user-guide#3-1-CVSS-Scoring-in-the-Exploit-Life-Cycle
@@ -69,5 +105,38 @@ describe('calculator', () => {
     expect(() =>
       calculateBaseScore('CVSS:2.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N')
     ).to.throw();
+  });
+});
+
+describe('Calculate correctly base scores', () => {
+  Object.entries(cvssTests).map((entry) => {
+    const cvss = entry[0];
+    const baseScore = entry[1][0];
+    it(`should calculate a score of ${baseScore} for ${cvss}`, () => {
+      const { score } = calculateBaseScore(cvss);
+      expect(score).to.equal(baseScore);
+    });
+  });
+});
+
+describe('Calculate correctly temporal scores', () => {
+  Object.entries(cvssTests).map((entry) => {
+    const cvss = entry[0];
+    const temporalScore = entry[1][1];
+    it(`should calculate a score of ${temporalScore} for ${cvss}`, () => {
+      const { score } = calculateTemporalScore(cvss);
+      expect(score).to.equal(temporalScore);
+    });
+  });
+});
+
+describe('Calculate correctly environmental scores', () => {
+  Object.entries(cvssTests).map((entry) => {
+    const cvss = entry[0];
+    const environmentalScore = entry[1][2];
+    it(`should calculate a score of ${environmentalScore} for ${cvss}`, () => {
+      const { score } = calculateEnvironmentalScore(cvss);
+      expect(score).to.equal(environmentalScore);
+    });
   });
 });

--- a/tests/validator.spec.ts
+++ b/tests/validator.spec.ts
@@ -61,4 +61,18 @@ describe('parser', () => {
       validate('CVSS:3.1/AV:N/AC:L//PR:N/UI:N/S:C/C:H/I:H/A:H')
     ).to.throw('Invalid');
   });
+
+  it('should produce exception on double separator', () => {
+    expect(() =>
+      validate('CVSS:3.1/AV:N/AC:L//PR:N/UI:N/S:C/C:H/I:H/A:H')
+    ).to.throw('Invalid');
+  });
+
+  it('should not throw when validating extra scopes', () => {
+    expect(() =>
+      validate(
+        'CVSS:3.0/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:H/RL:U/RC:C/CR:M/IR:M/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:H/MI:H/MA:H'
+      )
+    ).not.to.throw();
+  });
 });

--- a/tests/validator.spec.ts
+++ b/tests/validator.spec.ts
@@ -61,18 +61,4 @@ describe('parser', () => {
       validate('CVSS:3.1/AV:N/AC:L//PR:N/UI:N/S:C/C:H/I:H/A:H')
     ).to.throw('Invalid');
   });
-
-  it('should produce exception on double separator', () => {
-    expect(() =>
-      validate('CVSS:3.1/AV:N/AC:L//PR:N/UI:N/S:C/C:H/I:H/A:H')
-    ).to.throw('Invalid');
-  });
-
-  it('should not throw when validating extra scopes', () => {
-    expect(() =>
-      validate(
-        'CVSS:3.0/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:H/RL:U/RC:C/CR:M/IR:M/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:H/MI:H/MA:H'
-      )
-    ).not.to.throw();
-  });
 });


### PR DESCRIPTION
Adds the possibility to  returns temporal and environemental scores according to a given cvss vector string.  
Exactly like we can see here: https://www.first.org/cvss/calculator/3.1  

Also reworks score's tests in order to efficiently cover every sort of scores