### PR TITLE
ci: node version bump to 14 due to semantic-release

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [11.x, 12.x, 13.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm version --no-git-tag-version "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GPR_TOKEN }}
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Semantic release
         run: npx semantic-release


### PR DESCRIPTION
```
Run npx semantic-release
npx: installed 529 in 18.607s
[semantic-release]: node version >=16 || ^14.17 is required. Found v12.22.10.

See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
Error: Process completed with exit code 1.
```